### PR TITLE
Fix #1 (formatting bug when first decimal place is 0)

### DIFF
--- a/src/Data/Text/Format/Numbers.hs
+++ b/src/Data/Text/Format/Numbers.hs
@@ -35,7 +35,7 @@ prettyF PrettyCfg{..} n =
           else prettyI pc_thousandsSep intPart
       postDecimal =
           if pc_decimals > 0
-          then T.cons pc_decimalSep (T.justifyLeft pc_decimals '0' $ T.pack $ show decPart)
+          then T.cons pc_decimalSep (T.justifyRight pc_decimals '0' $ T.pack $ show decPart)
           else ""
   in preDecimal <> postDecimal
 

--- a/test/Data/Text/Format/NumbersSpec.hs
+++ b/test/Data/Text/Format/NumbersSpec.hs
@@ -29,6 +29,9 @@ spec =
               formatTest (p 1 ' ' ',') 12.1 "12,1"
               formatTest (p 2 ' ' ',') 12.1 "12,10"
               formatTest (prettyF $ PrettyCfg 2 Nothing ',') 1200.1 "1200,10"
+              formatTest (prettyF $ PrettyCfg 2 Nothing '.') 1200.01 "1200.01"
+              formatTest (prettyF $ PrettyCfg 3 Nothing '.') 1200.01 "1200.010"
+              formatTest (prettyF $ PrettyCfg 3 Nothing '.') 1200.001 "1200.001"
        describe "prettyInt" $
            do formatTestI (prettyI $ Just ',') 81601710123 "81,601,710,123"
               formatTestI (prettyI $ Just ' ') 81601710123 "81 601 710 123"


### PR DESCRIPTION
Pads with 0 on the left, not the right, if the decimal part is too short