### PR TITLE
Fix small negative floats

### DIFF
--- a/src/Data/Text/Format/Numbers.hs
+++ b/src/Data/Text/Format/Numbers.hs
@@ -29,10 +29,7 @@ prettyF PrettyCfg{..} n =
       lshifti' = abs lshiftr
       intPart = lshifti' `div` tpow
       decPart = lshifti' - intPart * tpow
-      preDecimal =
-          if lshiftr < 0
-          then prettyI pc_thousandsSep (intPart * (-1))
-          else prettyI pc_thousandsSep intPart
+      preDecimal = (if lshiftr < 0 then "-" else "") <> prettyI pc_thousandsSep intPart
       postDecimal =
           if pc_decimals > 0
           then T.cons pc_decimalSep (T.justifyRight pc_decimals '0' $ T.pack $ show decPart)

--- a/test/Data/Text/Format/NumbersSpec.hs
+++ b/test/Data/Text/Format/NumbersSpec.hs
@@ -28,6 +28,8 @@ spec =
               formatTest (p 0 ' ' ',') 12.1 "12"
               formatTest (p 1 ' ' ',') 12.1 "12,1"
               formatTest (p 2 ' ' ',') 12.1 "12,10"
+              formatTest (p 2 ' ' ',') 0.123 "0,12"
+              formatTest (p 2 ' ' ',') (-0.123) "-0,12"
               formatTest (prettyF $ PrettyCfg 2 Nothing ',') 1200.1 "1200,10"
               formatTest (prettyF $ PrettyCfg 2 Nothing '.') 1200.01 "1200.01"
               formatTest (prettyF $ PrettyCfg 3 Nothing '.') 1200.01 "1200.010"


### PR DESCRIPTION
`prettyF` function had wrong behavior for e.g. `n=-0.5`: when `intPart` is zero, then multiplying by -1 has no effect and minus sign goes missing.